### PR TITLE
Use py2/py3 compatible generator syntax

### DIFF
--- a/tests/test_with.py
+++ b/tests/test_with.py
@@ -193,14 +193,14 @@ class TestWithStatement(vmtest.VmTestCase):
 
                 def __enter__(self):
                     try:
-                        return self.gen.next()
+                        return next(self.gen)
                     except StopIteration:
                         raise RuntimeError("generator didn't yield")
 
                 def __exit__(self, type, value, traceback):
                     if type is None:
                         try:
-                            self.gen.next()
+                            next(self.gen)
                         except StopIteration:
                             return
                         else:
@@ -262,14 +262,14 @@ class TestWithStatement(vmtest.VmTestCase):
 
                 def __enter__(self):
                     try:
-                        return self.gen.next()
+                        return next(self.gen)
                     except StopIteration:
                         raise RuntimeError("generator didn't yield")
 
                 def __exit__(self, type, value, traceback):
                     if type is None:
                         try:
-                            self.gen.next()
+                            next(self.gen)
                         except StopIteration:
                             return
                         else:


### PR DESCRIPTION
In py2, generators have gen.next() methods.  In py3, it's gen.**next**().  Using next(gen) works in both versions.
