### PR TITLE
Break run_frame into some smaller components.

### DIFF
--- a/byterun/pyvm2.py
+++ b/byterun/pyvm2.py
@@ -166,6 +166,141 @@ class VirtualMachine(object):
             tb, value, exctype = self.popn(3)
             self.last_exception = exctype, value, tb
 
+    def parse_byte_and_args(self):
+        f = self.frame
+        opoffset = f.f_lasti
+        byteCode = byteint(f.f_code.co_code[opoffset])
+        f.f_lasti += 1
+        byteName = dis.opname[byteCode]
+        arg = None
+        arguments = []
+        if byteCode >= dis.HAVE_ARGUMENT:
+            arg = f.f_code.co_code[f.f_lasti:f.f_lasti+2]
+            f.f_lasti += 2
+            intArg = byteint(arg[0]) + (byteint(arg[1]) << 8)
+            if byteCode in dis.hasconst:
+                arg = f.f_code.co_consts[intArg]
+            elif byteCode in dis.hasfree:
+                if intArg < len(f.f_code.co_cellvars):
+                    arg = f.f_code.co_cellvars[intArg]
+                else:
+                    var_idx = intArg - len(f.f_code.co_cellvars)
+                    arg = f.f_code.co_freevars[var_idx]
+            elif byteCode in dis.hasname:
+                arg = f.f_code.co_names[intArg]
+            elif byteCode in dis.hasjrel:
+                arg = f.f_lasti + intArg
+            elif byteCode in dis.hasjabs:
+                arg = intArg
+            elif byteCode in dis.haslocal:
+                arg = f.f_code.co_varnames[intArg]
+            else:
+                arg = intArg
+            arguments = [arg]
+
+        return byteName, arguments, opoffset
+
+    def log(self, byteName, arguments, opoffset):
+        op = "%d: %s" % (opoffset, byteName)
+        if arguments:
+            op += " %r" % (arguments[0],)
+        indent = "    "*(len(self.frames)-1)
+        stack_rep = repper(self.stack)
+        block_stack_rep = repper(self.frame.block_stack)
+
+        log.info("  %sdata: %s" % (indent, stack_rep))
+        log.info("  %sblks: %s" % (indent, block_stack_rep))
+        log.info("%s%s" % (indent, op))
+
+    def dispatch(self, byteName, arguments):
+        why = None
+        try:
+            if byteName.startswith('UNARY_'):
+                self.unaryOperator(byteName[6:])
+            elif byteName.startswith('BINARY_'):
+                self.binaryOperator(byteName[7:])
+            elif byteName.startswith('INPLACE_'):
+                self.inplaceOperator(byteName[8:])
+            elif 'SLICE+' in byteName:
+                self.sliceOperator(byteName)
+            else:
+                # dispatch
+                bytecode_fn = getattr(self, 'byte_%s' % byteName, None)
+                if not bytecode_fn:            # pragma: no cover
+                    raise VirtualMachineError(
+                        "unknown bytecode type: %s" % byteName
+                    )
+                why = bytecode_fn(*arguments)
+
+        except:
+            # deal with exceptions encountered while executing the op.
+            self.last_exception = sys.exc_info()[:2] + (None,)
+            log.exception("Caught exception during execution")
+            why = 'exception'
+
+        return why
+
+    def manage_block_stack(self, why):
+        assert why != 'yield'
+
+        block = self.frame.block_stack[-1]
+        if block.type == 'loop' and why == 'continue':
+            self.jump(self.return_value)
+            why = None
+            return why
+
+        self.pop_block()
+        self.unwind_block(block)
+
+        if block.type == 'loop' and why == 'break':
+            why = None
+            self.jump(block.handler)
+            return why
+
+        if PY2:
+            if (
+                block.type == 'finally' or
+                (block.type == 'setup-except' and why == 'exception') or
+                block.type == 'with'
+            ):
+                if why == 'exception':
+                    exctype, value, tb = self.last_exception
+                    self.push(tb, value, exctype)
+                else:
+                    if why in ('return', 'continue'):
+                        self.push(self.return_value)
+                    self.push(why)
+
+                why = None
+                self.jump(block.handler)
+                return why
+
+        elif PY3:
+            if (
+                why == 'exception' and
+                block.type in ['setup-except', 'finally']
+            ):
+                self.push_block('except-handler')
+                exctype, value, tb = self.last_exception
+                self.push(tb, value, exctype)
+                # PyErr_Normalize_Exception goes here
+                self.push(tb, value, exctype)
+                why = None
+                self.jump(block.handler)
+                return why
+
+            elif block.type == 'finally':
+                if why in ('return', 'continue'):
+                    self.push(self.return_value)
+                self.push(why)
+
+                why = None
+                self.jump(block.handler)
+                return why
+
+        return why
+
+
     def run_frame(self, frame):
         """Run a frame until it returns (somehow).
 
@@ -174,78 +309,13 @@ class VirtualMachine(object):
         """
         self.push_frame(frame)
         while True:
-            opoffset = frame.f_lasti
-            byteCode = byteint(frame.f_code.co_code[opoffset])
-            frame.f_lasti += 1
-            byteName = dis.opname[byteCode]
-            arg = None
-            arguments = []
-            if byteCode >= dis.HAVE_ARGUMENT:
-                arg = frame.f_code.co_code[frame.f_lasti:frame.f_lasti+2]
-                frame.f_lasti += 2
-                intArg = byteint(arg[0]) + (byteint(arg[1]) << 8)
-                if byteCode in dis.hasconst:
-                    arg = frame.f_code.co_consts[intArg]
-                elif byteCode in dis.hasfree:
-                    if intArg < len(frame.f_code.co_cellvars):
-                        arg = frame.f_code.co_cellvars[intArg]
-                    else:
-                        var_idx = intArg - len(frame.f_code.co_cellvars)
-                        arg = frame.f_code.co_freevars[var_idx]
-                elif byteCode in dis.hasname:
-                    arg = frame.f_code.co_names[intArg]
-                elif byteCode in dis.hasjrel:
-                    arg = frame.f_lasti + intArg
-                elif byteCode in dis.hasjabs:
-                    arg = intArg
-                elif byteCode in dis.haslocal:
-                    arg = frame.f_code.co_varnames[intArg]
-                else:
-                    arg = intArg
-                arguments = [arg]
-
+            byteName, arguments, opoffset = self.parse_byte_and_args()
             if log.isEnabledFor(logging.INFO):
-                op = "%d: %s" % (opoffset, byteName)
-                if arguments:
-                    op += " %r" % (arguments[0],)
-                indent = "    "*(len(self.frames)-1)
-                stack_rep = repper(self.stack)
-                block_stack_rep = repper(self.frame.block_stack)
-
-                log.info("  %sdata: %s" % (indent, stack_rep))
-                log.info("  %sblks: %s" % (indent, block_stack_rep))
-                log.info("%s%s" % (indent, op))
+                self.log(byteName, arguments, opoffset)
 
             # When unwinding the block stack, we need to keep track of why we
             # are doing it.
-            why = None
-
-            try:
-                if byteName.startswith('UNARY_'):
-                    self.unaryOperator(byteName[6:])
-                elif byteName.startswith('BINARY_'):
-                    self.binaryOperator(byteName[7:])
-                elif byteName.startswith('INPLACE_'):
-                    self.inplaceOperator(byteName[8:])
-                elif 'SLICE+' in byteName:
-                    self.sliceOperator(byteName)
-                else:
-                    # dispatch
-                    bytecode_fn = getattr(self, 'byte_%s' % byteName, None)
-                    if not bytecode_fn:            # pragma: no cover
-                        raise VirtualMachineError(
-                            "unknown bytecode type: %s" % byteName
-                        )
-                    why = bytecode_fn(*arguments)
-
-            except:
-                # deal with exceptions encountered while executing the op.
-                self.last_exception = sys.exc_info()[:2] + (None,)
-                log.exception("Caught exception during execution")
-                why = 'exception'
-
-            # Deal with any block management we need to do.
-
+            why = self.dispatch(byteName, arguments)
             if why == 'exception':
                 # TODO: ceval calls PyTraceBack_Here, not sure what that does.
                 pass
@@ -255,61 +325,8 @@ class VirtualMachine(object):
 
             if why != 'yield':
                 while why and frame.block_stack:
-
-                    assert why != 'yield'
-
-                    block = frame.block_stack[-1]
-                    if block.type == 'loop' and why == 'continue':
-                        self.jump(self.return_value)
-                        why = None
-                        break
-
-                    self.pop_block()
-                    self.unwind_block(block)
-
-                    if block.type == 'loop' and why == 'break':
-                        why = None
-                        self.jump(block.handler)
-                        break
-
-                    if PY2:
-                        if (
-                            block.type == 'finally' or
-                            (block.type == 'setup-except' and why == 'exception') or
-                            block.type == 'with'
-                        ):
-                            if why == 'exception':
-                                exctype, value, tb = self.last_exception
-                                self.push(tb, value, exctype)
-                            else:
-                                if why in ('return', 'continue'):
-                                    self.push(self.return_value)
-                                self.push(why)
-
-                            why = None
-                            self.jump(block.handler)
-                            break
-                    elif PY3:
-                        if (
-                            why == 'exception' and
-                            block.type in ['setup-except', 'finally']
-                        ):
-                            self.push_block('except-handler')
-                            exctype, value, tb = self.last_exception
-                            self.push(tb, value, exctype)
-                            # PyErr_Normalize_Exception goes here
-                            self.push(tb, value, exctype)
-                            why = None
-                            self.jump(block.handler)
-
-                        elif block.type == 'finally':
-                            if why in ('return', 'continue'):
-                                self.push(self.return_value)
-                            self.push(why)
-
-                            why = None
-                            self.jump(block.handler)
-                            break
+                    # Deal with any block management we need to do.
+                    why = self.manage_block_stack(why)
 
             if why:
                 break
@@ -320,8 +337,6 @@ class VirtualMachine(object):
             six.reraise(*self.last_exception)
 
         return self.return_value
-
-
 
     ## Stack manipulation
 


### PR DESCRIPTION
This breaks apart the many jobs of run_frame into parsing arguments, dispatching to bytecode functions, and manipulating the block stack (and also logging).  It makes the structure slightly more removed from CPython's ceval, but I think it's much more readable.
