### PR TITLE
Add Py3.4 support.

### DIFF
--- a/byterun/pyobj.py
+++ b/byterun/pyobj.py
@@ -2,6 +2,7 @@
 
 import collections
 import inspect
+import re
 import types
 
 import six
@@ -61,11 +62,12 @@ class Function(object):
             return self
 
     def __call__(self, *args, **kwargs):
-        if PY2 and self.func_name in ["<setcomp>", "<dictcomp>", "<genexpr>"]:
+        if re.search(r'<(listcomp|setcomp|dictcomp|genexpr)>$', self.func_name):
             # D'oh! http://bugs.python.org/issue19611 Py2 doesn't know how to
             # inspect set comprehensions, dict comprehensions, or generator
             # expressions properly.  They are always functions of one argument,
-            # so just do the right thing.
+            # so just do the right thing.  Py3.4 also would fail without this
+            # hack, for list comprehensions too. (Haven't checked for other 3.x.)
             assert len(args) == 1 and not kwargs, "Surprising comprehension!"
             callargs = {".0": args[0]}
         else:

--- a/byterun/pyvm2.py
+++ b/byterun/pyvm2.py
@@ -421,7 +421,10 @@ class VirtualMachine(object):
         elif name in f.f_builtins:
             val = f.f_builtins[name]
         else:
-            raise NameError("global name '%s' is not defined" % name)
+            if PY2:
+                raise NameError("global name '%s' is not defined" % name)
+            elif PY3:
+                raise NameError("name '%s' is not defined" % name)
         self.push(val)
 
     def byte_LOAD_DEREF(self, name):

--- a/byterun/pyvm2.py
+++ b/byterun/pyvm2.py
@@ -1045,18 +1045,14 @@ if PY3:
         assert isinstance(name, str)
         # This is simplified in that we don't yet handle metaclasses. So we do
         # make sure there is no metaclass, before proceeding.
-        metaclass = kwds.get('metaclass') # (We don't just write 'metaclass=None'
-        # in the signature above because that's a syntax error in Py2.)
-        assert metaclass is None
-        assert not kwds
+        assert not kwds # No explicit metaclass or keyword arguments to the metaclass.
         for base in bases:
-            assert type(base) == type
+            assert type(base) == type # No implicit metaclass from the bases.
         # OK, no metaclass; we may proceed.
         # XXX What about func.func_closure? vm.make_frame() gives us no way to pass it in.
         # We'll come back to fix this; for now, just make sure this case doesn't come up.
         assert not func.func_closure
         ns = {}
         frame = func._vm.make_frame(func.func_code, f_globals=func.func_globals, f_locals=ns)
-        
-        func_result = func._vm.run_frame(frame)
+        func._vm.run_frame(frame)
         return type(name, bases, ns)

--- a/byterun/pyvm2.py
+++ b/byterun/pyvm2.py
@@ -1029,7 +1029,7 @@ class VirtualMachine(object):
     elif PY3:
         def byte_LOAD_BUILD_CLASS(self):
             # New in py3
-            self.push(__build_class__)
+            self.push(build_class)
 
         def byte_STORE_LOCALS(self):
             self.frame.f_locals = self.pop()
@@ -1037,3 +1037,26 @@ class VirtualMachine(object):
     if 0:   # Not in py2.7
         def byte_SET_LINENO(self, lineno):
             self.frame.f_lineno = lineno
+
+if PY3:
+    def build_class(func, name, *bases, **kwds):
+        "Simplified (i.e., wrong) version of __build_class__."
+        assert isinstance(func, Function)
+        assert isinstance(name, str)
+        # This is simplified in that we don't yet handle metaclasses. So we do
+        # make sure there is no metaclass, before proceeding.
+        metaclass = kwds.get('metaclass') # (We don't just write 'metaclass=None'
+        # in the signature above because that's a syntax error in Py2.)
+        assert metaclass is None
+        assert not kwds
+        for base in bases:
+            assert type(base) == type
+        # OK, no metaclass; we may proceed.
+        # XXX What about func.func_closure? vm.make_frame() gives us no way to pass it in.
+        # We'll come back to fix this; for now, just make sure this case doesn't come up.
+        assert not func.func_closure
+        ns = {}
+        frame = func._vm.make_frame(func.func_code, f_globals=func.func_globals, f_locals=ns)
+        
+        func_result = func._vm.run_frame(frame)
+        return type(name, bases, ns)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33
+envlist = py27, py33, py34
 
 [testenv]
 commands =


### PR DESCRIPTION
With these patches the tests pass in Py3.4. This isn't done yet because I had to reimplement `__build_class__`, and that reimplementation doesn't yet support metaclasses or closures. It looks like the closure support will need to share a fix with issue #17, so I'm going to take a look at that next. I'm just opening this pull request now to let you know what's up -- maybe I should've opened an issue instead?

Another idea could be to wrap the built-in `__build_class__` primitive, passing it a Python function object for which it'd do the right thing, but `__build_class__` is magical enough that that seems difficult.

There are also fixes for a couple of other problems that came up in running the tests in 3.4.

(I haven't tested 3.5 or 3.6, or 3.3 yet either. It does still pass the tests in 2.7.)

My motivation is to get my Python bytecode compiler https://github.com/darius/500lines/blob/master/bytecode-compiler/bytecompiler.rewrite.md to run on top of a bytecode interpreter also in Python. My compiler's for Py3.4 only.