### PR TITLE
builtin discovery

### DIFF
--- a/byterun/pyobj.py
+++ b/byterun/pyobj.py
@@ -141,10 +141,11 @@ class Frame(object):
         self.f_locals = f_locals
         self.f_back = f_back
         self.stack = []
-        if f_back:
+        if f_back and f_back.f_globals is f_globals:
+            # If we share the globals, we share the builtins.
             self.f_builtins = f_back.f_builtins
         else:
-            self.f_builtins = f_locals['__builtins__']
+            self.f_builtins = f_globals['__builtins__']
             if hasattr(self.f_builtins, '__dict__'):
                 self.f_builtins = self.f_builtins.__dict__
 

--- a/byterun/pyobj.py
+++ b/byterun/pyobj.py
@@ -145,9 +145,13 @@ class Frame(object):
             # If we share the globals, we share the builtins.
             self.f_builtins = f_back.f_builtins
         else:
-            self.f_builtins = f_globals['__builtins__']
-            if hasattr(self.f_builtins, '__dict__'):
-                self.f_builtins = self.f_builtins.__dict__
+            try:
+                self.f_builtins = f_globals['__builtins__']
+                if hasattr(self.f_builtins, '__dict__'):
+                    self.f_builtins = self.f_builtins.__dict__
+            except KeyError:
+                # No builtins! Make up a minimal one with None.
+                self.f_builtins = {'None': None}
 
         self.f_lineno = f_code.co_firstlineno
         self.f_lasti = 0


### PR DESCRIPTION
Fixes two issues in the way the builtins get found for a frame:

1. The builtins are only inherited from the parent if `f_back.f_globals is f_globals`.
2. If we can't inherit the builtins and the name `__builtins__` is undefined in the `f_globals`, then the builtins are a new dictionary with a value of `{'None': None}`.

References to the CPython source are provided in the two commit messages. 