### PR TITLE
Two fixes to get 3.3 tests working

### DIFF
--- a/byterun/pyobj.py
+++ b/byterun/pyobj.py
@@ -22,21 +22,38 @@ def make_cell(value):
 
 class Function(object):
     __slots__ = [
-        'func_code', 'func_name', 'func_defaults', 'func_globals',
-        'func_locals', 'func_dict', 'func_closure',
-        '__name__', '__dict__', '__doc__',
+        'func_code',  # Python 2.x
+        'func_name',
+        'func_defaults',
+        'func_closure',
+
+        "__code__",  # Python 3.x
+        '__name__',
+        '__defaults__',
+        '__closure__',
+
+        'func_globals',
+        'func_locals', 'func_dict',
+
+
+        '__dict__', '__doc__',
         '_vm', '_func',
     ]
 
     def __init__(self, name, code, globs, defaults, closure, vm):
         self._vm = vm
-        self.func_code = code
+
+        # Function field names below change between Python 2.7 and 3.x.
+        # We create attibutes for both names. Other code in this file assumes
+        # 2.7ish names, while bytecode for 3.x will use 3.x names.
+        self.func_code = self.__code__ = code
         self.func_name = self.__name__ = name or code.co_name
-        self.func_defaults = tuple(defaults)
+        self.func_defaults = self.__defaults__ = tuple(defaults)
+        self.func_closure = self.__closure__ = closure
+
         self.func_globals = globs
         self.func_locals = self._vm.frame.f_locals
         self.__dict__ = {}
-        self.func_closure = closure
         self.__doc__ = code.co_consts[0] if code.co_consts else None
 
         # Sometimes, we need a real Python function.  This is for that.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -22,10 +22,10 @@ class TestIt(vmtest.VmTestCase):
                 xyz+=1
                 print("Midst:",xyz)
 
-            
-            print "Pre:",xyz
+
+            print("Pre:",xyz)
             abc()
-            print "Post:",xyz
+            print("Post:",xyz)
             """)
 
     def test_for_loop(self):


### PR DESCRIPTION
I get the following errors when trying this on Python 3.3: 
[3.3-nosetests.log](https://github.com/nedbat/byterun/files/4548525/3.3-nosetests.log)

This patch addresses these.

* Some functions in pyobj.py like Function#__repr__ () assume3 2.7ish
  fields even when working on 3.x bytcode. When Running 3.3 bytecode
  though, 3.x names appear
* change `print ...` to `print(..)` in test_basic.py so this works on 3.x

The fork that I've started though has a number of other changes since I'll be revising this to use the cross version bytecode routines in [xdis](https://pypi.org/project/xdis/). 

FYI, I see a lot of potential in here by mixing this with the `xdis` and the Python debugger's I've written. For example inside a debugger one could try out (simple) code in a sandboxed environment.

And it also works the other way too &mdash; various debugger modules  could be used in a debugger for this interpreter . With the cross-bycode routines there is a greater potentail to write one program that can run several different sets of bytecode versions.  (I'm waving my hands here *a lot*, but I do think it could be used for more than just pedagogic purposes.)