### PR TITLE
Fix a bug in closures. Lexcical scoping for closures.

### DIFF
--- a/byterun/pyvm2.py
+++ b/byterun/pyvm2.py
@@ -90,7 +90,7 @@ class VirtualMachine(object):
     def pop_block(self):
         return self.frame.block_stack.pop()
 
-    def make_frame(self, code, callargs={}, f_globals=None, f_locals=None):
+    def make_frame(self, code, callargs={}, f_globals=None, f_locals=None, f_func_obj=None):
         log.info("make_frame: code=%r, callargs=%s" % (code, repper(callargs)))
         if f_globals is not None:
             f_globals = f_globals
@@ -107,7 +107,7 @@ class VirtualMachine(object):
                 '__package__': None,
             }
         f_locals.update(callargs)
-        frame = Frame(code, f_globals, f_locals, self.frame)
+        frame = Frame(code, f_globals, f_locals, self.frame, f_func_obj)
         return frame
 
     def push_frame(self, frame):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -296,6 +296,17 @@ class TestClosures(vmtest.VmTestCase):
             assert answer == 54
             """)
 
+    def test_lexical_scope(self):
+        self.assert_ok("""\
+            def f(x, z):
+                def g(y):
+                    return x + y + z
+                return g
+            g1 = f(3, 4)
+            g2 = f(5, 6)
+            assert g1(100) == 107
+            assert g2(100) == 111
+            """)
 
 class TestGenerators(vmtest.VmTestCase):
     def test_first(self):


### PR DESCRIPTION
Fix a bug in closures. It seems that lexical scoping was not implemented correctly in byterun. 
Please refer to the new test case (i.e., test_lexical_scope()) in tests/test_functions.py.
```python
def f(x, z):
	def g(y):
		return x + y + z
	return g

g1 = f(3, 4)
g2 = f(5, 6)
# BUG: the result of g1(100) is not 107. 
assert g1(100) == 107
assert g2(100) == 111
```